### PR TITLE
Fix BroadcastReceiver ANR

### DIFF
--- a/spwaitkiller/src/main/java/com/knightboot/spwaitkiller/ProxyFinishersLinkedList.java
+++ b/spwaitkiller/src/main/java/com/knightboot/spwaitkiller/ProxyFinishersLinkedList.java
@@ -33,4 +33,9 @@ public class ProxyFinishersLinkedList<T> extends ConcurrentLinkedQueue<T> {
     public boolean remove(@Nullable Object o) {
         return sPendingWorkFinishers.remove(o);
     }
+
+    @Override
+    public boolean isEmpty() {
+        return true;
+    }
 }

--- a/spwaitkiller/src/main/java/com/knightboot/spwaitkiller/ProxyFinishersList.java
+++ b/spwaitkiller/src/main/java/com/knightboot/spwaitkiller/ProxyFinishersList.java
@@ -33,4 +33,9 @@ public class ProxyFinishersList<T> extends LinkedList<T> {
     public boolean remove(@Nullable Object o) {
         return sFinishers.remove(o);
     }
+
+    @Override
+    public boolean isEmpty() {
+        return true;
+    }
 }

--- a/spwaitkiller/src/main/java/com/knightboot/spwaitkiller/ProxySWork.java
+++ b/spwaitkiller/src/main/java/com/knightboot/spwaitkiller/ProxySWork.java
@@ -80,7 +80,7 @@ class ProxySWork<T> extends LinkedList<T> {
 
     @Override
     public boolean isEmpty() {
-        return proxy.isEmpty();
+        return true;
     }
 
 


### PR DESCRIPTION
广播需要判断LinkedList.isEmpty 方法

```
//ActivityThread.java
private void handleReceiver(ReceiverData data) {
    // ...
    if (receiver.getPendingResult() != null) {
        //通知AMS，取消BROADCAST_TIMEOUT_MSG消息
        data.finish();
    }
}

//data.finish()
public final void finish() {
    if (mType == TYPE_COMPONENT) {//静态注册的广播
        final IActivityManager mgr = ActivityManager.getService();
        if (QueuedWork.hasPendingWork()) {
            //当SP有未同步到磁盘的工作，则需等待其完成，才告知系统已完成该广播
            QueuedWork.queue(new Runnable() {
                public void run() {
                    sendFinished(mgr);
                }
            }, false);
        } else {
            sendFinished(mgr);
        }
    } else if (mOrderedHint && mType != TYPE_UNREGISTERED) {//动态注册的串行广播
        final IActivityManager mgr = ActivityManager.getService();
        sendFinished(mgr);
    }
}

//QueuedWork.java
public static boolean hasPendingWork() {
      synchronized (sLock) {
          return !sWork.isEmpty();
      }
  }
```