### PR TITLE
   fix issue#7

### DIFF
--- a/app/src/main/java/com/knightboot/spwaitkiller/sample/MainActivity.java
+++ b/app/src/main/java/com/knightboot/spwaitkiller/sample/MainActivity.java
@@ -101,14 +101,13 @@ public class MainActivity extends AppCompatActivity {
                 @Override
                 public void run() {
                     try {
-                        Log.d(TAG,"run work "+Log.getStackTraceString(new Throwable()));
-                        Log.e(TAG,"run work "+this+" on Thread "+Thread.currentThread().getId()+" begin");
+                        Log.e(TAG,"run work "+this+" on Thread "+Thread.currentThread().getName()+" begin");
                         Thread.sleep(blockSeconds*1000);
                         writtenToDiskLatch.countDown();
                     } catch (InterruptedException e) {
                         e.printStackTrace();
                     }
-                    Log.e(TAG,"run work "+this+" on Thread "+Thread.currentThread().getId() +" finish");
+                    Log.e(TAG,"run work "+this+" on Thread "+Thread.currentThread().getName() +" finish");
                 }
             });
             //触发任务执行

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ android.enableJetifier=true
 
 
 GROUP=io.github.knight-zxw
-VERSION_NAME=0.0.7-SNAPSHOT
+VERSION_NAME=0.0.8-SNAPSHOT
 POM_DESCRIPTION=android sp blocking killer
 
 POM_URL=https://github.com/Knight-ZXW/SpWaitKiller/

--- a/spwaitkiller/src/main/java/com/knightboot/spwaitkiller/ProxySWork.java
+++ b/spwaitkiller/src/main/java/com/knightboot/spwaitkiller/ProxySWork.java
@@ -6,7 +6,6 @@ import android.os.Looper;
 
 import androidx.annotation.NonNull;
 
-import java.util.ArrayList;
 import java.util.LinkedList;
 
 /**
@@ -17,13 +16,13 @@ class ProxySWork<T> extends LinkedList<T> {
 
     private final Handler sHandler;
 
-    private final QueueWorkAspect queueWorkAspect;
+    private final AboveAndroid12Processor aboveAndroid12Processor;
 
     public ProxySWork(LinkedList<T> proxy,
-                      Looper looper, QueueWorkAspect queueWorkAspect) {
+                      Looper looper, AboveAndroid12Processor aboveAndroid12Processor) {
         this.proxy = proxy;
         sHandler = new Handler(looper);
-        this.queueWorkAspect = queueWorkAspect;
+        this.aboveAndroid12Processor = aboveAndroid12Processor;
     }
 
     // is thread safe
@@ -65,7 +64,7 @@ class ProxySWork<T> extends LinkedList<T> {
         //Android 12 change:
         if (Build.VERSION.SDK_INT>=Build.VERSION_CODES.S){
             delegateWork();
-            this.queueWorkAspect.processPendingWorkDone();
+            this.aboveAndroid12Processor.reProxySWork();
             return 0;
         }else {
             return proxy.size();
@@ -83,10 +82,15 @@ class ProxySWork<T> extends LinkedList<T> {
         return true;
     }
 
+    /**
+     * Android 12及以上版本的特殊回调处理
+     */
+    interface AboveAndroid12Processor {
 
-    interface QueueWorkAspect {
-
-        public void processPendingWorkDone();
+        /**
+         * 重新代理 sWork字段
+         */
+        public void reProxySWork();
 
     }
 }


### PR DESCRIPTION
    在Android12及以上版本，每次调用ProcessPendingWork时，在 work.size()函数执行时， sWork字段已被指向为一个新的集合对象，因此 在执行代理work.size()的逻辑后，应当重新设置sWork字段，并且需要代理这个新的集合对象